### PR TITLE
tree.rs: lift id and name into a struct type

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -88,7 +88,7 @@ impl Filesystem for TreeFs {
                             child.id,
                             1,
                             TreeFs::tree_to_file_type(child),
-                            child.name.to_owned()
+                            &child.name
                         ));
                     }
                     reply.ok();

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -1,3 +1,4 @@
+use crate::tree::Contents;
 use crate::tree::Tree;
 use fuser::FileAttr;
 use fuser::FileType;
@@ -15,10 +16,10 @@ use std::time::UNIX_EPOCH;
 pub fn run(tree: Tree) {
     eprintln!("mounting on /tmp/mnt");
     fuser::mount2(
-        TreeFs(Tree::Node {
+        TreeFs(Tree {
             id: 1,
             name: "root".to_owned(),
-            children: vec![tree],
+            contents: Contents::Node(vec![tree]),
         }),
         "/tmp/mnt",
         &vec![MountOption::AutoUnmount, MountOption::DefaultPermissions],
@@ -31,9 +32,9 @@ struct TreeFs(Tree);
 
 impl TreeFs {
     fn tree_to_file_type(tree: &Tree) -> FileType {
-        match tree {
-            Tree::Node { .. } => FileType::Directory,
-            Tree::Leaf { .. } => FileType::RegularFile,
+        match tree.contents {
+            Contents::Node(_) => FileType::Directory,
+            Contents::Leaf(_) => FileType::RegularFile,
         }
     }
 }
@@ -78,13 +79,16 @@ impl Filesystem for TreeFs {
         eprintln!("readdir - offset: {:?}", offset);
         match offset {
             0 => match self.0.get_by_id(ino) {
-                Some(Tree::Node { children, .. }) => {
+                Some(Tree {
+                    contents: Contents::Node(children),
+                    ..
+                }) => {
                     for child in children {
                         assert!(!reply.add(
-                            child.id(),
+                            child.id,
                             1,
                             TreeFs::tree_to_file_type(child),
-                            child.name()
+                            child.name.to_owned()
                         ));
                     }
                     reply.ok();
@@ -98,14 +102,17 @@ impl Filesystem for TreeFs {
     fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
         eprintln!("lookup: {:?} / {:?}", parent, name);
         match self.0.get_by_id(parent) {
-            Some(Tree::Node { children, .. }) => {
+            Some(Tree {
+                contents: Contents::Node(children),
+                ..
+            }) => {
                 let child = children
                     .iter()
-                    .find(|child| child.name() == &name.to_string_lossy());
+                    .find(|child| child.name == name.to_string_lossy());
                 match child {
                     Some(child) => {
                         let attr = FileAttr {
-                            ino: child.id(),
+                            ino: child.id,
                             size: 13,
                             blocks: 1,
                             atime: UNIX_EPOCH,
@@ -143,7 +150,10 @@ impl Filesystem for TreeFs {
     ) {
         eprintln!("read");
         match self.0.get_by_id(ino) {
-            Some(Tree::Leaf { contents, .. }) => reply.data(contents.as_bytes()),
+            Some(Tree {
+                contents: Contents::Leaf(string),
+                ..
+            }) => reply.data(string.as_bytes()),
             _ => todo!(),
         }
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -6,9 +6,9 @@ pub enum Contents {
 
 #[derive(Debug)]
 pub struct Tree {
-    pub(crate) id: u64,
-    pub(crate) name: String,
-    pub(crate) contents: Contents,
+    pub id: u64,
+    pub name: String,
+    pub contents: Contents,
 }
 
 impl Tree {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,46 +1,24 @@
 #[derive(Debug)]
-pub enum Tree {
-    Leaf {
-        id: u64,
-        name: String,
-        contents: String,
-    },
-    Node {
-        id: u64,
-        name: String,
-        children: Vec<Tree>,
-    },
+pub enum Contents {
+    Leaf(String),
+    Node(Vec<Tree>),
+}
+
+#[derive(Debug)]
+pub struct Tree {
+    pub(crate) id: u64,
+    pub(crate) name: String,
+    pub(crate) contents: Contents,
 }
 
 impl Tree {
-    pub fn id(&self) -> u64 {
-        match self {
-            Tree::Leaf { id, .. } => *id,
-            Tree::Node { id, .. } => *id,
-        }
-    }
-
-    pub fn name(&self) -> &str {
-        match self {
-            Tree::Leaf { name, .. } => name,
-            Tree::Node { name, .. } => name,
-        }
-    }
-
-    pub fn name_mut(&mut self) -> &mut String {
-        match self {
-            Tree::Leaf { name, .. } => name,
-            Tree::Node { name, .. } => name,
-        }
-    }
-
     pub fn get_by_id(&self, id: u64) -> Option<&Tree> {
-        if self.id() == id {
+        if self.id == id {
             return Some(self);
         }
-        match self {
-            Tree::Leaf { .. } => None,
-            Tree::Node { children, .. } => {
+        match &self.contents {
+            Contents::Leaf(_) => None,
+            Contents::Node(children) => {
                 for child in children {
                     if let Some(found) = child.get_by_id(id) {
                         return Some(found);
@@ -52,14 +30,14 @@ impl Tree {
     }
 
     pub fn uniquify_names(&mut self) {
-        match self {
-            Tree::Node { children, .. } => {
+        match self.contents {
+            Contents::Node(ref mut children) => {
                 for (i, child) in children.iter_mut().enumerate() {
-                    child.name_mut().insert_str(0, &format!("{i}-"));
+                    child.name.insert_str(0, &format!("{i}-"));
                     child.uniquify_names();
                 }
             }
-            Tree::Leaf { .. } => {}
+            Contents::Leaf(_) => {}
         }
     }
 }

--- a/src/treesitter.rs
+++ b/src/treesitter.rs
@@ -1,3 +1,4 @@
+use crate::tree::Contents;
 use crate::tree::Tree;
 use std::fs;
 use tree_sitter::Node;
@@ -22,17 +23,13 @@ fn to_tree(code: &str, node: Node) -> Tree {
     for child in node.children(&mut cursor) {
         children.push(to_tree(code, child));
     }
-    if children.is_empty() {
-        Tree::Leaf {
-            id: node.id().try_into().unwrap(),
-            name: node.grammar_name().to_owned(),
-            contents: node.utf8_text(code.as_bytes()).unwrap().to_owned(),
-        }
-    } else {
-        Tree::Node {
-            id: node.id().try_into().unwrap(),
-            name: node.grammar_name().to_owned(),
-            children,
-        }
+    Tree {
+        id: node.id().try_into().unwrap(),
+        name: node.grammar_name().to_owned(),
+        contents: if children.is_empty() {
+            Contents::Leaf(node.utf8_text(code.as_bytes()).unwrap().to_owned())
+        } else {
+            Contents::Node(children)
+        },
     }
 }


### PR DESCRIPTION
use a new variant type `Contents` to disambiguate leaves from nodes